### PR TITLE
refactor: harden concurrency and context propagation

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,7 +36,7 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "valentine-p2p"
+rootProject.name = "unicorn"
 
 val excludedProjects = providers.gradleProperty("excludeProjects")
     .map { it.split(",") }

--- a/unicorn-core/src/main/java/com/lwohvye/core/exception/UtilsException.java
+++ b/unicorn-core/src/main/java/com/lwohvye/core/exception/UtilsException.java
@@ -18,8 +18,12 @@ package com.lwohvye.core.exception;
 
 public class UtilsException extends RuntimeException {
 
-	public UtilsException(String message) {
-		super(message);
-	}
+    public UtilsException(String message) {
+        super(message);
+    }
+
+    public UtilsException(String message, Throwable cause) {
+        super(message, cause);
+    }
 
 }

--- a/unicorn-core/src/main/java/com/lwohvye/core/utils/ConcurrencyUtils.java
+++ b/unicorn-core/src/main/java/com/lwohvye/core/utils/ConcurrencyUtils.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2022-2025.  lWoHvYe(Hongyan Wang)
+ *    Copyright (c) 2022-2026.  lWoHvYe(Hongyan Wang)
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -33,55 +33,57 @@ import java.util.function.Function;
 public class ConcurrencyUtils extends UnicornAbstractThreadUtils {
 
     /**
-     * Basic flow : execute tasks, the result as the input of composeResult, the previous res as the input of eventual
+     * Execute all tasks concurrently, compose their results, and optionally consume the composed result.
      *
-     * @param composeResult consume the task res
-     * @param eventual      finally execute, consume the res of  composeResult
-     * @param tasks         tasks wtd
+     * <p>All task failures are propagated and the compose/eventual callbacks are invoked only after every
+     * task has completed successfully. A task returning {@code null} keeps its position in the result list.</p>
+     *
+     * @param composeResult consume the task results
+     * @param eventual finally execute, consuming the composed result
+     * @param tasks tasks to execute concurrently
      */
     public static <T, U> void structuredExecute(Function<List<T>, U> composeResult, Consumer<U> eventual, Callable<T>... tasks) {
-        log.warn("In Java 17 Source");
-        List<CompletableFuture<T>> futures = null;
-        if (Objects.nonNull(tasks)) {
-            futures = Arrays.stream(tasks).map(task -> CompletableFuture.supplyAsync(() -> {
-                try {
-                    return task.call();
-                } catch (Exception e) {
-                    throw new UtilsException(e.getMessage());
-                }
-            }, TASK_EXECUTOR)).toList();
-            var allCF = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
-            // whenComplete 只是一个处理完成状态的方法，它不会吞掉异常，也不会改变 CompletableFuture 的状态。
-            allCF.whenComplete((voidResult, throwable) -> {
-                if (throwable == null) {
-                    log.info("All tasks completed successfully");
-                } else {
-                    log.warn("Exception occurred when execute task: {} ", throwable.getMessage());
-                }
-            });
-            allCF.join(); // This will still throw an exception if any of the futures failed
-        }
-        U results = null;
-        if (Objects.nonNull(composeResult))
-            results = composeResult.apply(Objects.nonNull(futures) ?
-                    futures.stream().map(CompletableFuture::join).filter(Objects::nonNull).toList() : Collections.emptyList());
-        if (Objects.nonNull(eventual))
-            eventual.accept(results);
+        log.debug("Executing tasks with Java 17 concurrency implementation");
+        List<CompletableFuture<T>> futures = tasks == null
+                ? Collections.emptyList()
+                : Arrays.stream(tasks)
+                .map(Objects::requireNonNull)
+                .map(task -> CompletableFuture.supplyAsync(() -> {
+                    try {
+                        return task.call();
+                    } catch (Exception e) {
+                        throw new UtilsException("Task execution failed", e);
+                    }
+                }, TASK_EXECUTOR))
+                .toList();
 
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        U results = null;
+        if (composeResult != null) {
+            results = composeResult.apply(futures.isEmpty()
+                    ? Collections.emptyList()
+                    : futures.stream().map(CompletableFuture::join).toList());
+        }
+        if (eventual != null) {
+            eventual.accept(results);
+        }
     }
 
-    // Returns a Callable object that, when called, runs the given task and returns null.
-    // var callable = Executors.callable(runnable) // Runnable 2 Callable
-    // A FutureTask can be used to wrap a Callable or Runnable object. Because FutureTask implements Runnable, a FutureTask can be submitted to an Executor for execution.
-    // var futureTask = new FutureTask<T>(Callable/Runnable) // Callable/Runnable 2 Runnable/Future
+    /**
+     * Execute all tasks concurrently and invoke {@code eventual} after successful completion.
+     */
     public static void structuredExecute(Runnable eventual, Runnable... tasks) {
-        log.warn("In Java 17 Source");
-        if (Objects.nonNull(tasks)) {
-            var futureTasks = Arrays.stream(tasks).map(task -> CompletableFuture.runAsync(task, TASK_EXECUTOR)).toList();
-            CompletableFuture.allOf(futureTasks.toArray(new CompletableFuture[0])).join();
+        log.debug("Executing tasks with Java 17 concurrency implementation");
+        if (tasks != null) {
+            var futures = Arrays.stream(tasks)
+                    .map(Objects::requireNonNull)
+                    .map(task -> CompletableFuture.runAsync(task, TASK_EXECUTOR))
+                    .toList();
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
         }
-        // Here, both forks have succeeded, so compose their results
-        if (Objects.nonNull(eventual))
+        if (eventual != null) {
             eventual.run();
+        }
     }
 }

--- a/unicorn-core/src/main/java/com/lwohvye/core/utils/UnicornAbstractThreadUtils.java
+++ b/unicorn-core/src/main/java/com/lwohvye/core/utils/UnicornAbstractThreadUtils.java
@@ -23,9 +23,11 @@ import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
+import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestAttributesThreadLocalAccessor;
 import org.springframework.web.context.request.RequestContextHolder;
 
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Supplier;
@@ -39,90 +41,86 @@ public abstract class UnicornAbstractThreadUtils {
 
     public static final ExecutorService TASK_EXECUTOR = Executors.newFixedThreadPool(8);
 
-    // 1. 创建一个只包含特定 Accessor 的 Registry
-    static ContextRegistry limitedRegistry = new ContextRegistry()
-            .registerThreadLocalAccessor(new ObservationThreadLocalAccessor())         // 只传 Observation
-            .registerThreadLocalAccessor(new RequestAttributesThreadLocalAccessor());  // 或自定义字段
+    private static final ContextRegistry limitedRegistry = new ContextRegistry()
+            .registerThreadLocalAccessor(new ObservationThreadLocalAccessor())
+            .registerThreadLocalAccessor(new RequestAttributesThreadLocalAccessor());
 
-    // 2. 使用这个受限的 Registry 创建工厂
-    static ContextSnapshotFactory selectiveFactory = ContextSnapshotFactory.builder()
+    private static final ContextSnapshotFactory selectiveFactory = ContextSnapshotFactory.builder()
             .contextRegistry(limitedRegistry)
             .build();
 
-    // 使用自定义工厂
     public static ExecutorService wrap(ExecutorService executor) {
         return ContextExecutorService.wrap(executor, () -> selectiveFactory.captureAll());
     }
 
     public static Runnable decorateObservation(Runnable runnable) {
-        // 获取当前 Observation 并包装任务
         var currentObservation = SpringContextHolder.getBean(ObservationRegistry.class).getCurrentObservation();
-        if (currentObservation != null) {
-            // 包装后的任务在执行时会自动恢复并清理 Trace 上下文
-            return currentObservation.wrap(runnable);
-        } else {
-            return runnable;
-        }
+        return currentObservation != null ? currentObservation.wrap(runnable) : runnable;
     }
 
     public static <U> Supplier<U> decorateObservation(Supplier<U> supplier) {
-        // 获取当前 Observation 并包装任务
         var currentObservation = SpringContextHolder.getBean(ObservationRegistry.class).getCurrentObservation();
-        if (currentObservation != null) {
-            // 包装后的任务在执行时会自动恢复并清理 Trace 上下文
-            return currentObservation.wrap(supplier);
-        } else {
-            return supplier;
-        }
+        return currentObservation != null ? currentObservation.wrap(supplier) : supplier;
     }
 
     public static Runnable decorateMdc(Runnable runnable) {
-        var mdc = MDC.getCopyOfContextMap();
+        Map<String, String> capturedMdc = MDC.getCopyOfContextMap();
         return () -> {
+            Map<String, String> previousMdc = MDC.getCopyOfContextMap();
             try {
-                MDC.setContextMap(mdc);
+                restoreMdc(capturedMdc);
                 runnable.run();
             } finally {
-                MDC.clear();
+                restoreMdc(previousMdc);
             }
         };
     }
 
     public static <U> Supplier<U> decorateMdc(Supplier<U> supplier) {
-        var mdc = MDC.getCopyOfContextMap();
+        Map<String, String> capturedMdc = MDC.getCopyOfContextMap();
         return () -> {
+            Map<String, String> previousMdc = MDC.getCopyOfContextMap();
             try {
-                MDC.setContextMap(mdc);
+                restoreMdc(capturedMdc);
                 return supplier.get();
             } finally {
-                MDC.clear();
+                restoreMdc(previousMdc);
             }
         };
     }
 
-    // 将HttpRequest传递到子线程，使用线程池时可以这样做，但也需要考虑性能问题。如果是直接创建子线程就不用这么麻烦，想办法像下面将inheritable设置为true就行
     public static Runnable decorateRequest(Runnable runnable) {
-        var requestAttributes = RequestContextHolder.currentRequestAttributes();
+        RequestAttributes capturedAttributes = RequestContextHolder.currentRequestAttributes();
         return () -> {
+            RequestAttributes previousAttributes = RequestContextHolder.getRequestAttributes();
             try {
-                RequestContextHolder.setRequestAttributes(requestAttributes, true);
+                RequestContextHolder.setRequestAttributes(capturedAttributes, false);
                 runnable.run();
             } finally {
-                RequestContextHolder.resetRequestAttributes();
+                RequestContextHolder.setRequestAttributes(previousAttributes, false);
             }
         };
     }
 
     public static <U> Supplier<U> decorateRequest(Supplier<U> supplier) {
-        var requestAttributes = RequestContextHolder.currentRequestAttributes();
+        RequestAttributes capturedAttributes = RequestContextHolder.currentRequestAttributes();
         return () -> {
+            RequestAttributes previousAttributes = RequestContextHolder.getRequestAttributes();
             try {
-                RequestContextHolder.setRequestAttributes(requestAttributes, true);
+                RequestContextHolder.setRequestAttributes(capturedAttributes, false);
                 return supplier.get();
             } finally {
-                RequestContextHolder.resetRequestAttributes();
+                RequestContextHolder.setRequestAttributes(previousAttributes, false);
             }
         };
+    }
+
+    private static void restoreMdc(Map<String, String> contextMap) {
+        if (contextMap == null || contextMap.isEmpty()) {
+            MDC.clear();
+        } else {
+            MDC.setContextMap(contextMap);
+        }
     }
 
 }

--- a/unicorn-core/src/main/java/module-info.java
+++ b/unicorn-core/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 // 暂作为open module。允许其他模块通过反射访问，后续缩小范围
 @SuppressWarnings({"requires-automatic", "requires-transitive-automatic"})
-        // 抑制compile warn: requires transitive directive for an automatic module
+// 抑制compile warn: requires transitive directive for an automatic module
 module lwohvye.unicorn.core {
     requires transitive java.compiler;
     requires java.desktop;
@@ -28,26 +28,26 @@ module lwohvye.unicorn.core {
     requires transitive spring.boot;
     requires transitive spring.boot.autoconfigure;
     requires transitive tools.jackson.databind;
-    requires transitive com.github.benmanes.caffeine;
-    requires transitive cn.hutool;
-    requires transitive io.swagger.v3.oas.models;
-    requires transitive io.swagger.v3.oas.annotations;
+    requires com.github.benmanes.caffeine;
+    requires cn.hutool;
+    requires io.swagger.v3.oas.models;
+    requires io.swagger.v3.oas.annotations;
     requires transitive lombok;
     requires mica.ip2region;
     requires transitive org.apache.commons.codec;
     requires org.apache.commons.lang3;
     requires transitive org.apache.commons.logging;
-    requires transitive org.apache.poi.poi;
-    requires transitive org.apache.poi.ooxml;
+    requires org.apache.poi.poi;
+    requires org.apache.poi.ooxml;
     requires transitive org.aspectj.weaver;
     requires transitive org.hibernate.orm.core;
     requires org.jetbrains.annotations;
     requires transitive org.mapstruct;
-    requires transitive org.slf4j;
-    requires transitive org.springdoc.openapi.common;
+    requires org.slf4j;
+    requires org.springdoc.openapi.common;
     requires transitive redisson;
-    requires transitive org.bouncycastle.pkix;
-    requires transitive org.bouncycastle.provider;
+    requires org.bouncycastle.pkix;
+    requires org.bouncycastle.provider;
     requires net.coobird.thumbnailator;
     requires reactor.core;
     requires spring.security.oauth2.jose;

--- a/unicorn-core/src/main/java21/com/lwohvye/core/utils/ConcurrencyUtils.java
+++ b/unicorn-core/src/main/java21/com/lwohvye/core/utils/ConcurrencyUtils.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2022-2025.  lWoHvYe(Hongyan Wang)
+ *    Copyright (c) 2022-2026.  lWoHvYe(Hongyan Wang)
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,71 +23,85 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static java.util.concurrent.StructuredTaskScope.Subtask;
 
 /**
- * This class provides utility methods for handling concurrency and executing tasks in a structured manner.
+ * Utilities for executing tasks with structured concurrency on Java 21+ runtimes.
  */
 @UtilityClass
 public class ConcurrencyUtils extends UnicornAbstractThreadUtils {
 
     /**
-     * Basic flow : execute tasks, the result as the input of composeResult, the previous res as the input of eventual
+     * Execute all tasks in a {@link java.util.concurrent.StructuredTaskScope.ShutdownOnFailure}, compose their
+     * results, and optionally consume the composed result. If one task fails, sibling tasks are cancelled.
      *
-     * @param composeResult consume the task res
-     * @param eventual      finally execute, consume the res of  composeResult
-     * @param tasks         tasks wtd
+     * @param composeResult consume the task results
+     * @param eventual finally execute, consuming the composed result
+     * @param tasks tasks to execute concurrently
      */
     public static <T, U> void structuredExecute(Function<List<T>, U> composeResult, Consumer<U> eventual, Callable<T>... tasks) {
-        try (var scope = new StructuredTaskScope.ShutdownOnFailure("STS-JUC", virtualFactory)) {
-            List<Subtask<T>> subtasks = null;
-            if (Objects.nonNull(tasks))
-                subtasks = Arrays.stream(tasks).map(scope::fork).toList();
+        try (var scope = new java.util.concurrent.StructuredTaskScope.ShutdownOnFailure("STS-JUC", virtualFactory)) {
+            List<Subtask<T>> subtasks = tasks == null
+                    ? Collections.emptyList()
+                    : Arrays.stream(tasks)
+                    .map(Objects::requireNonNull)
+                    .map(scope::fork)
+                    .toList();
 
-            scope.join()           // Join both forks
-                    .throwIfFailed();  // ... and propagate errors
+            scope.join().throwIfFailed();
 
-            // Here, both forks have succeeded, so compose their results
             U results = null;
-            if (Objects.nonNull(composeResult))
-                results = composeResult.apply(Objects.nonNull(subtasks) ?
-                        subtasks.stream().map(Subtask::get).filter(Objects::nonNull).toList() : Collections.emptyList());
-            if (Objects.nonNull(eventual))
+            if (composeResult != null) {
+                results = composeResult.apply(subtasks.stream().map(Subtask::get).toList());
+            }
+            if (eventual != null) {
                 eventual.accept(results);
+            }
         } catch (ExecutionException e) {
-            if (e.getCause() instanceof RuntimeException re)
-                throw re;
-            throw new UtilsException(e.getMessage());
+            rethrowTaskFailure(e.getCause());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            throw new UtilsException("Structured task execution was interrupted", e);
         }
     }
 
-    // Returns a Callable object that, when called, runs the given task and returns null.
-    // var callable = Executors.callable(runnable) // Runnable 2 Callable
-    // A FutureTask can be used to wrap a Callable or Runnable object. Because FutureTask implements Runnable, a FutureTask can be submitted to an Executor for execution.
-    // var futureTask = new FutureTask<T>(Callable/Runnable) // Callable/Runnable 2 Runnable/Future
+    /**
+     * Execute all tasks concurrently and invoke {@code eventual} after successful completion.
+     */
     public static void structuredExecute(Runnable eventual, Runnable... tasks) {
-        try (var scope = new StructuredTaskScope.ShutdownOnFailure("STS-JUC", virtualFactory)) {
-            if (Objects.nonNull(tasks))
-                Arrays.stream(tasks).forEach(runnable -> scope.fork(Executors.callable(runnable)));
+        try (var scope = new java.util.concurrent.StructuredTaskScope.ShutdownOnFailure("STS-JUC", virtualFactory)) {
+            if (tasks != null) {
+                Arrays.stream(tasks)
+                        .map(Objects::requireNonNull)
+                        .forEach(task -> scope.fork(Executors.callable(task)));
+            }
 
-            scope.join()           // Join both forks
-                    .throwIfFailed();  // ... and propagate errors
+            scope.join().throwIfFailed();
 
-            // Here, both forks have succeeded, so compose their results
-            if (Objects.nonNull(eventual))
+            if (eventual != null) {
                 eventual.run();
+            }
         } catch (ExecutionException e) {
-            if (e.getCause() instanceof RuntimeException re)
-                throw re;
-            throw new UtilsException(e.getMessage());
+            rethrowTaskFailure(e.getCause());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            throw new UtilsException("Structured task execution was interrupted", e);
         }
+    }
+
+    private static void rethrowTaskFailure(Throwable cause) {
+        if (cause instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        }
+        if (cause instanceof Error error) {
+            throw error;
+        }
+        throw new UtilsException("Structured task execution failed", cause);
     }
 }

--- a/unicorn-core/src/main/java21/com/lwohvye/core/utils/UnicornAbstractThreadUtils.java
+++ b/unicorn-core/src/main/java21/com/lwohvye/core/utils/UnicornAbstractThreadUtils.java
@@ -23,9 +23,11 @@ import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
+import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestAttributesThreadLocalAccessor;
 import org.springframework.web.context.request.RequestContextHolder;
 
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -33,7 +35,6 @@ import java.util.function.Supplier;
 
 /**
  * Represents a utility class for handling threads in a virtualized environment.
- * This abstract class provides a thread factory and an executor service for executing tasks.
  *
  * @since 21
  */
@@ -47,112 +48,85 @@ public abstract class UnicornAbstractThreadUtils {
     static final ThreadFactory virtualFactory = Thread.ofVirtual().name("Virtual-Concurrency").factory();
     public static final ExecutorService TASK_EXECUTOR = Executors.newThreadPerTaskExecutor(virtualFactory);
 
-    // https://stackoverflow.com/questions/78122797/how-to-propagate-traceid-to-other-threads-in-one-transaction-for-spring-boot-3-x
-    // 1. 创建一个只包含特定 Accessor 的 Registry
-    static ContextRegistry limitedRegistry = new ContextRegistry()
-            .registerThreadLocalAccessor(new ObservationThreadLocalAccessor())         // 只传 Observation
-            .registerThreadLocalAccessor(new RequestAttributesThreadLocalAccessor());  // 或自定义字段
+    private static final ContextRegistry limitedRegistry = new ContextRegistry()
+            .registerThreadLocalAccessor(new ObservationThreadLocalAccessor())
+            .registerThreadLocalAccessor(new RequestAttributesThreadLocalAccessor());
 
-    // 2. 使用这个受限的 Registry 创建工厂
-    static ContextSnapshotFactory selectiveFactory = ContextSnapshotFactory.builder()
+    private static final ContextSnapshotFactory selectiveFactory = ContextSnapshotFactory.builder()
             .contextRegistry(limitedRegistry)
             .build();
 
-    // 使用自定义工厂
     public static ExecutorService wrap(ExecutorService executor) {
         return ContextExecutorService.wrap(executor, () -> selectiveFactory.captureAll());
     }
 
     public static Runnable decorateObservation(Runnable runnable) {
-        // 获取当前 Observation 并包装任务
         var currentObservation = SpringContextHolder.getBean(ObservationRegistry.class).getCurrentObservation();
-        if (currentObservation != null) {
-            // 包装后的任务在执行时会自动恢复并清理 Trace 上下文
-            return currentObservation.wrap(runnable);
-        } else {
-            return runnable;
-        }
+        return currentObservation != null ? currentObservation.wrap(runnable) : runnable;
     }
 
     public static <U> Supplier<U> decorateObservation(Supplier<U> supplier) {
-        // 获取当前 Observation 并包装任务
         var currentObservation = SpringContextHolder.getBean(ObservationRegistry.class).getCurrentObservation();
-        if (currentObservation != null) {
-            // 包装后的任务在执行时会自动恢复并清理 Trace 上下文
-            return currentObservation.wrap(supplier);
-        } else {
-            return supplier;
-        }
+        return currentObservation != null ? currentObservation.wrap(supplier) : supplier;
     }
 
-    // 下面这个，就是解决InheritableThreadLocal 和 ThreadPool一起使用时的问题，使用ThreadLocal 然后自行实现值的传递
-    // 因为ITL只在Thread Create时传递，而ThreadPool通常是share的，所以当run CompletableFuture时，ITL会失效，
-    // 对此可以在每次run一批Task时 Create New ThreadPool，且避免Thread的复用，因为若复用Thread仍会有该问题,这有悖Pool的部分初衷了
-    // 当使用Virtual Threads时，虽然也可以定义ThreadPool,但每次都是New Thread，不会复用，是否还有这个问题，待验证，但用VT时，更推荐用ScopedValue
-/*
-    public static final ThreadLocal<Object> threadLocal = new ThreadLocal<>();
-
-    public static Runnable withTLTP(Runnable runnable) {
-        var sharedVar = ConcurrencyUtils.threadLocal.get();
-        return () -> {
-            ConcurrencyUtils.threadLocal.set(sharedVar);
-            runnable.run();
-        };
-    }*/
-//    {
-//        // 使用下面这两种方式，可以将traceId等ThreadLocal传到子线程，且ThreadPool的复用不受影响
-//        ExecutorService executor = ContextExecutorService.wrap(Executors.newSingleThreadExecutor());
-//        var executorService = wrap(Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()));
-//          配合下面这个传递custom MDC，另外可以考虑TaskDecorator
-//        ContextRegistry.getInstance().registerThreadLocalAccessor("MDC",MDC::getCopyOfContextMap, MDC::setContextMap, MDC::clear);
-//    }
-
-    // 下面这俩采用类似的思想
     public static Runnable decorateMdc(Runnable runnable) {
-        var mdc = MDC.getCopyOfContextMap();
+        Map<String, String> capturedMdc = MDC.getCopyOfContextMap();
         return () -> {
+            Map<String, String> previousMdc = MDC.getCopyOfContextMap();
             try {
-                MDC.setContextMap(mdc);
+                restoreMdc(capturedMdc);
                 runnable.run();
             } finally {
-                MDC.clear();
+                restoreMdc(previousMdc);
             }
         };
     }
 
     public static <U> Supplier<U> decorateMdc(Supplier<U> supplier) {
-        var mdc = MDC.getCopyOfContextMap();
+        Map<String, String> capturedMdc = MDC.getCopyOfContextMap();
         return () -> {
+            Map<String, String> previousMdc = MDC.getCopyOfContextMap();
             try {
-                MDC.setContextMap(mdc);
+                restoreMdc(capturedMdc);
                 return supplier.get();
             } finally {
-                MDC.clear();
+                restoreMdc(previousMdc);
             }
         };
     }
 
     public static Runnable decorateRequest(Runnable runnable) {
-        var requestAttributes = RequestContextHolder.currentRequestAttributes();
+        RequestAttributes capturedAttributes = RequestContextHolder.currentRequestAttributes();
         return () -> {
+            RequestAttributes previousAttributes = RequestContextHolder.getRequestAttributes();
             try {
-                RequestContextHolder.setRequestAttributes(requestAttributes, true);
+                RequestContextHolder.setRequestAttributes(capturedAttributes, false);
                 runnable.run();
             } finally {
-                RequestContextHolder.resetRequestAttributes();
+                RequestContextHolder.setRequestAttributes(previousAttributes, false);
             }
         };
     }
 
     public static <U> Supplier<U> decorateRequest(Supplier<U> supplier) {
-        var requestAttributes = RequestContextHolder.currentRequestAttributes();
+        RequestAttributes capturedAttributes = RequestContextHolder.currentRequestAttributes();
         return () -> {
+            RequestAttributes previousAttributes = RequestContextHolder.getRequestAttributes();
             try {
-                RequestContextHolder.setRequestAttributes(requestAttributes, true);
+                RequestContextHolder.setRequestAttributes(capturedAttributes, false);
                 return supplier.get();
             } finally {
-                RequestContextHolder.resetRequestAttributes();
+                RequestContextHolder.setRequestAttributes(previousAttributes, false);
             }
         };
+    }
+
+    private static void restoreMdc(Map<String, String> contextMap) {
+        if (contextMap == null || contextMap.isEmpty()) {
+            MDC.clear();
+        } else {
+            MDC.setContextMap(contextMap);
+        }
     }
 }

--- a/unicorn-core/unicorn-core.gradle.kts
+++ b/unicorn-core/unicorn-core.gradle.kts
@@ -67,11 +67,13 @@ publishing {
 }
 
 dependencies {
-    api(platform(SpringBootPlugin.BOM_COORDINATES))
+    implementation(platform(SpringBootPlugin.BOM_COORDINATES))
+
+    // Spring Boot capabilities that form Unicorn Core's runtime surface.
     api("org.springframework.boot:spring-boot-starter-data-jpa")
     api("org.springframework.boot:spring-boot-starter-webmvc")
     api("org.springframework.boot:spring-boot-starter-security")
-    api("org.springframework.boot:spring-boot-starter-restclient")
+    implementation("org.springframework.boot:spring-boot-starter-restclient")
     implementation("org.springframework.security:spring-security-access")
     implementation("org.springframework.security:spring-security-oauth2-jose")
     api("org.springframework.boot:spring-boot-starter-amqp")
@@ -79,20 +81,23 @@ dependencies {
     api("org.springframework.boot:spring-boot-starter-data-redis")
     api(libs.redisson)
     api(libs.redisson.cache)
-    api("org.apache.commons:commons-pool2")
-    api("org.apache.commons:commons-lang3")
-    api(libs.springdoc.webmvc.ui)
-    api(libs.hutool)
-    api(libs.ip2region)
-    api(libs.poi)
-    api(libs.poi.ooxml)
+
+    // Implementation details: these are used by Core itself but are not part of
+    // the public type surface and should not leak through published API metadata.
+    implementation("org.apache.commons:commons-pool2")
+    implementation("org.apache.commons:commons-lang3")
+    implementation(libs.springdoc.webmvc.ui)
+    implementation(libs.hutool)
+    implementation(libs.ip2region)
+    implementation(libs.poi)
+    implementation(libs.poi.ooxml)
     implementation(libs.xerces)
     api(libs.mapstruct)
     api(libs.mapstruct.spring.annotations)
-    api("com.github.ben-manes.caffeine:caffeine")
+    implementation("com.github.ben-manes.caffeine:caffeine")
     implementation(libs.logback.encoder)
-    api(libs.bouncycastle.pkix)
-    api(libs.thumbnailator)
+    implementation(libs.bouncycastle.pkix)
+    implementation(libs.thumbnailator)
     api(libs.jetbrains.annotations)
     api("org.springframework.boot:spring-boot-starter-actuator")
     api("io.micrometer:micrometer-tracing-bridge-brave")


### PR DESCRIPTION
First optimization batch based on the architecture review.

- preserve original MDC / RequestContextHolder state after decorated tasks
- avoid inheritable RequestAttributes propagation in explicit wrappers
- preserve null task results instead of silently dropping them
- preserve task failure causes in UtilsException
- treat null task arrays as empty execution sets
- use StructuredTaskScope failure propagation on Java 21+
- restore interrupt status and surface interruption instead of silently returning
- keep this as one coherent commit to avoid unnecessary CI runs